### PR TITLE
Color Key Fix and State Name Relocation

### DIFF
--- a/gradientUSMap.js
+++ b/gradientUSMap.js
@@ -266,7 +266,7 @@
 		d3.selectAll(".rectangle").remove();
 		for(var i = 0; i < boxNum; i++){
 			svg.append("rect")
-			   .attr("x", 50 + 25*i)
+			   .attr("x", 55 + 25*i)
 			   .attr("y", 10)
 			   .attr("width", 25)
 			   .attr("height", 25)
@@ -285,7 +285,7 @@
 		svg.append("text")
         	.attr("x", 0)
             .attr("y", 25)
-            .text("min = " + Number(min).toFixed(2))
+            .text("\00  min = " + Number(min).toFixed(2) + " ")
         	.attr("font-family", "sans-serif")
             .attr("font-size", "10px")
             .attr("fill", "black")
@@ -296,17 +296,18 @@
 	var drawMaxLabel = function(position) {
 		d3.select("#maxLabel").remove();
 		svg.append("text")
-        	.attr("x", position)
+        	.attr("x", 8 + position)
             .attr("y", 25)
-            .text("max = " + Number(max).toFixed(2))
+            .text("\00  max = " + Number(max).toFixed(2))
         	.attr("font-family", "sans-serif")
             .attr("font-size", "10px")
             .attr("fill", "black")
+            .attr("class", "text")
             .attr("id", "maxLabel");
 	}
 
 	var drawContinuousGrad = function(){
-		var minY = 10;
+		var minY = 15;
 		var maxY = 300;
 
 		d3.select("linearGradient").remove();
@@ -332,7 +333,7 @@
 		    
 		svg
 		    .append("rect")
-		    .attr("x", 50)
+		    .attr("x", 54)
 		    .attr("y", 10)
 		    .attr("width", 250)
 		    .attr("height", 25)
@@ -340,7 +341,7 @@
 		    .attr("class", "rectangle");
 
 		drawMinLabel();
-		drawMaxLabel(300);
+		drawMaxLabel(298);
 
 	}
 

--- a/style.css
+++ b/style.css
@@ -14,7 +14,13 @@ svg {
 	fill-opacity:0.5;
 }
 #stateName {
-	position: absolute;
+	display: block;
+	position: static;
+	text-align: center;
+	font-size: 20px;
+	font: 20px sans-serif;
+	margin: 2px;
+	color: black;
 }
 #tooltip {   
 	position: absolute;           


### PR DESCRIPTION
Fixed text location relative to the side of the SVG and the color key. Also just temporarily relocated the name of the state being viewed to below SVG instead of right side.
